### PR TITLE
install from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for intro to the codebase
 It can be installed using `go get`.
 
 ```
- $ go get github.com/dborzov/lsp
+ $ go get github.com/dborzov/lsp@master
 ```
 
 Then make sure that your `$PATH` includes the `$GOPATH/bin` directory.


### PR DESCRIPTION
Was quite confused when I installed via `go get github.com/dborzov` and it looked nothing like the README.

Using `master` may get more users to give it a try off the bat.

cheers!